### PR TITLE
Change blog for iteration data

### DIFF
--- a/src/assets/blog.njk
+++ b/src/assets/blog.njk
@@ -9,7 +9,7 @@ title: Blog
 {% for post in collections.posts %}
     <li>
         <a href="{{ post.url }}">
-            {{ page.data.title | default(page.url) }}
+            {{ post.data.title | default(post.url) }}
         </a>
     </li>
 {% endfor %}


### PR DESCRIPTION
Currently this page doesn't display currently because it's a `for post in`, but the rendering is copied from the index where it's a `for page in`. I've changed the rendering iteration data to be `post` as it makes more sense than being `page` in this context.